### PR TITLE
Fixes get_grid size mismatch bug

### DIFF
--- a/fastai2/vision/data.py
+++ b/fastai2/vision/data.py
@@ -75,8 +75,7 @@ def get_grid(n, rows=None, cols=None, add_vert=0, figsize=None, double=False, ti
     if double: cols*=2 ; n*=2
     figsize = (cols*3, rows*3+add_vert) if figsize is None else figsize
     fig,axs = subplots(rows, cols, figsize=figsize)
-    axs = axs.flatten()
-    for ax in axs[n:]: ax.set_axis_off()
+    axs = [ax if i<n else ax.set_axis_off() for i, ax in enumerate(axs.flatten())][:n]
     if title is not None: fig.suptitle(title, weight='bold', size=14)
     return (fig,axs) if return_fig else axs
 

--- a/nbs/09a_vision_data.ipynb
+++ b/nbs/09a_vision_data.ipynb
@@ -309,8 +309,7 @@
     "    if double: cols*=2 ; n*=2\n",
     "    figsize = (cols*3, rows*3+add_vert) if figsize is None else figsize\n",
     "    fig,axs = subplots(rows, cols, figsize=figsize)\n",
-    "    axs = axs.flatten()\n",
-    "    for ax in axs[n:]: ax.set_axis_off()\n",
+    "    axs = [ax if i<n else ax.set_axis_off() for i, ax in enumerate(axs.flatten())][:n]\n",
     "    if title is not None: fig.suptitle(title, weight='bold', size=14)\n",
     "    return (fig,axs) if return_fig else axs"
    ]
@@ -485,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -537,22 +536,15 @@
       "Converted 38_tutorial_ulmfit.ipynb.\n",
       "Converted 40_tabular_core.ipynb.\n",
       "Converted 41_tabular_model.ipynb.\n",
-      "Converted 42_tabular_rapids.ipynb.\n",
       "Converted 50_data_block_examples.ipynb.\n",
       "Converted 60_medical_imaging.ipynb.\n",
       "Converted 65_medical_text.ipynb.\n",
       "Converted 70_callback_wandb.ipynb.\n",
       "Converted 71_callback_tensorboard.ipynb.\n",
-      "Converted 90_notebook_core.ipynb.\n",
-      "Converted 91_notebook_export.ipynb.\n",
-      "Converted 92_notebook_showdoc.ipynb.\n",
-      "Converted 93_notebook_export2html.ipynb.\n",
-      "Converted 94_notebook_test.ipynb.\n",
+      "Converted 90_xse_resnext.ipynb.\n",
       "Converted 95_index.ipynb.\n",
       "Converted 96_data_external.ipynb.\n",
-      "Converted 97_utils_test.ipynb.\n",
-      "Converted notebook2jekyll.ipynb.\n",
-      "Converted xse_resnext.ipynb.\n"
+      "Converted 97_utils_test.ipynb.\n"
      ]
     }
    ],
@@ -586,7 +578,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Apply the changes discussed in #1 

I tried doing the change in a more compact way. The other approach would be to do `axs = axs[:n]` after line 79.

Let me know if you think that is a better idea.
