### PR TITLE
fixes norm init

### DIFF
--- a/fastai2/layers.py
+++ b/fastai2/layers.py
@@ -105,8 +105,9 @@ def _get_norm(prefix, nf, ndim=2, zero=False, **kwargs):
     "Norm layer with `nf` features and `ndim` initialized depending on `norm_type`."
     assert 1 <= ndim <= 3
     bn = getattr(nn, f"{prefix}{ndim}d")(nf, **kwargs)
-    bn.bias.data.fill_(1e-3)
-    bn.weight.data.fill_(0. if zero else 1.)
+    if bn.affine:
+        bn.bias.data.fill_(1e-3)
+        bn.weight.data.fill_(0. if zero else 1.)
     return bn
 
 #Cell

--- a/nbs/03a_layers.ipynb
+++ b/nbs/03a_layers.ipynb
@@ -384,8 +384,9 @@
     "    \"Norm layer with `nf` features and `ndim` initialized depending on `norm_type`.\"\n",
     "    assert 1 <= ndim <= 3\n",
     "    bn = getattr(nn, f\"{prefix}{ndim}d\")(nf, **kwargs)\n",
-    "    bn.bias.data.fill_(1e-3)\n",
-    "    bn.weight.data.fill_(0. if zero else 1.)\n",
+    "    if bn.affine:\n",
+    "        bn.bias.data.fill_(1e-3)\n",
+    "        bn.weight.data.fill_(0. if zero else 1.)\n",
     "    return bn "
    ]
   },
@@ -452,6 +453,23 @@
     "assert isinstance(tst, nn.InstanceNorm1d)\n",
     "tst = InstanceNorm(15, ndim=3)\n",
     "assert isinstance(tst, nn.InstanceNorm3d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If `affine` is false the weight should be `None`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(BatchNorm(15, affine=False).weight, None)\n",
+    "test_eq(InstanceNorm(15, affine=False).weight, None)"
    ]
   },
   {


### PR DESCRIPTION
`_get_norm` was raising an error when `affine=False` because `bn.weight` is `None`. We should only initialize weights if `affine=True`.