### PR TITLE
fixes in_channels

### DIFF
--- a/fastai2/layers.py
+++ b/fastai2/layers.py
@@ -562,5 +562,6 @@ class NoneReduce():
 def in_channels(m):
     "Return the shape of the first weight layer in `m`."
     for l in flatten_model(m):
-        if hasattr(l, 'weight'): return l.weight.shape[1]
+        if getattr(l, 'weight', None) is not None and l.weight.ndim==4:
+            return l.weight.shape[1]
     raise Exception('No weight layer')

--- a/nbs/03a_layers.ipynb
+++ b/nbs/03a_layers.ipynb
@@ -837,10 +837,10 @@
     {
      "data": {
       "text/plain": [
-       "tensor([[0.9462, 0.2176, 1.1637, 1.0847, 2.1841],\n",
-       "        [1.1505, 0.2564, 0.5705, 0.1417, 0.4491],\n",
-       "        [1.1819, 0.3416, 0.9731, 1.1677, 0.4468],\n",
-       "        [1.0149, 0.5942, 0.4926, 0.8175, 1.3723]])"
+       "tensor([[0.4903, 0.3746, 0.3920, 1.2246, 0.3775],\n",
+       "        [0.1420, 1.1166, 1.1062, 1.0383, 0.2785],\n",
+       "        [0.4781, 0.4127, 0.7474, 0.1698, 0.5183],\n",
+       "        [0.2942, 0.7503, 0.4956, 0.8066, 0.6134]])"
       ]
      },
      "execution_count": null,
@@ -1933,7 +1933,8 @@
     "def in_channels(m):\n",
     "    \"Return the shape of the first weight layer in `m`.\"\n",
     "    for l in flatten_model(m):\n",
-    "        if hasattr(l, 'weight'): return l.weight.shape[1]\n",
+    "        if getattr(l, 'weight', None) is not None and l.weight.ndim==4:\n",
+    "            return l.weight.shape[1]\n",
     "    raise Exception('No weight layer')"
    ]
   },
@@ -1945,6 +1946,10 @@
    "source": [
     "test_eq(in_channels(nn.Sequential(nn.Conv2d(5,4,3), nn.Conv2d(4,3,3))), 5)\n",
     "test_eq(in_channels(nn.Sequential(nn.AvgPool2d(4), nn.Conv2d(4,3,3))), 4)\n",
+    "test_eq(in_channels(nn.Sequential(BatchNorm(4), nn.Conv2d(4,3,3))), 4)\n",
+    "test_eq(in_channels(nn.Sequential(InstanceNorm(4), nn.Conv2d(4,3,3))), 4)\n",
+    "#TODO: Only possible if #9 is merged\n",
+    "#test_eq(in_channels(nn.Sequential(InstanceNorm(4, affine=False), nn.Conv2d(4,3,3))), 4)\n",
     "test_fail(lambda : in_channels(nn.Sequential(nn.AvgPool2d(4))))"
    ]
   },


### PR DESCRIPTION
Calling `in_channels` would fail if the first layer was a `Batch/Instance Norm` layer because this layers have an attribute called `weight`. If `affine=True` then the error was raised:
```python
~/forks/fastai2/fastai2/layers.py in in_channels(m)
    563     "Return the shape of the first weight layer in `m`."
    564     for l in flatten_model(m):
--> 565         if hasattr(l, 'weight'): return l.weight.shape[1]
    566     raise Exception('No weight layer')

IndexError: tuple index out of range
```

If `affine=False` the layer would still have `weight` but it would be None. One way of solving the issue would be to assert that the layer we are testing is a constitutional layer, but I found that would be too restrictive, maybe the user implements his own ConvLayer. So I check that the weights should have 4 dimensions, I think all convolutions should satisfy that.

---
Off topic:
One of the test depends on #9 being approved, so I commented it out. When I want to make multiple changes, should I create a branch and a separate PR for each of then or should I do everything together in a single branch?