### PR TITLE
batchsize error

### DIFF
--- a/fastai2/data/load.py
+++ b/fastai2/data/load.py
@@ -126,7 +126,7 @@ class DataLoader(GetAttr):
     def create_batch(self, b): return (fa_collate,fa_convert)[self.prebatched](b)
     def do_batch(self, b): return self.retain(self.create_batch(self.before_batch(b)), b)
     def one_batch(self):
-        if self.n < self.bs: raise ValueError(f'Batch size is {self.bs} but dataset only contains {self.n} items')
+        if self.n == 0: raise ValueError(f'Dataset does not contain any items')
         with self.fake_l.no_multiproc(): res = first(self)
         if hasattr(self, 'it'): delattr(self, 'it')
         return res

--- a/fastai2/data/load.py
+++ b/fastai2/data/load.py
@@ -126,6 +126,7 @@ class DataLoader(GetAttr):
     def create_batch(self, b): return (fa_collate,fa_convert)[self.prebatched](b)
     def do_batch(self, b): return self.retain(self.create_batch(self.before_batch(b)), b)
     def one_batch(self):
+        if self.n < self.bs: raise ValueError(f'Batch size is {self.bs} but dataset only contains {self.n} items')
         with self.fake_l.no_multiproc(): res = first(self)
         if hasattr(self, 'it'): delattr(self, 'it')
         return res

--- a/nbs/02_data.load.ipynb
+++ b/nbs/02_data.load.ipynb
@@ -230,7 +230,7 @@
     "    def create_batch(self, b): return (fa_collate,fa_convert)[self.prebatched](b)\n",
     "    def do_batch(self, b): return self.retain(self.create_batch(self.before_batch(b)), b)\n",
     "    def one_batch(self):\n",
-    "        if self.n < self.bs: raise ValueError(f'Batch size is {self.bs} but dataset only contains {self.n} items')\n",
+    "        if self.n == 0: raise ValueError(f'Dataset does not contain any items')\n",
     "        with self.fake_l.no_multiproc(): res = first(self)\n",
     "        if hasattr(self, 'it'): delattr(self, 'it')\n",
     "        return res"

--- a/nbs/02_data.load.ipynb
+++ b/nbs/02_data.load.ipynb
@@ -230,6 +230,7 @@
     "    def create_batch(self, b): return (fa_collate,fa_convert)[self.prebatched](b)\n",
     "    def do_batch(self, b): return self.retain(self.create_batch(self.before_batch(b)), b)\n",
     "    def one_batch(self):\n",
+    "        if self.n < self.bs: raise ValueError(f'Batch size is {self.bs} but dataset only contains {self.n} items')\n",
     "        with self.fake_l.no_multiproc(): res = first(self)\n",
     "        if hasattr(self, 'it'): delattr(self, 'it')\n",
     "        return res"


### PR DESCRIPTION
Just an added an error when batch size is bigger than dataset. A bit more helpful for debugging. Tested with:

    from fastai2.basics import *
    from fastai2.vision.all import *
    from fastai2.callback.all import *
    data = DataBlock(blocks=(ImageBlock, CategoryBlock), 
                 get_items=get_image_files, 
                 splitter=RandomSplitter(),
                 get_y=parent_label)
    path = untar_data(URLs.DOGS)

    bunch = data.databunch(path/"sample", item_tfms=RandomResizedCrop(460), bs=32, batch_tfms=[*aug_transforms(size=299, max_warp=0), Normalize.from_stats(*imagenet_stats)])

    bunch.show_batch()