### PR TITLE
fix learn.summary for multiple outputs

### DIFF
--- a/fastai2/callback/hook.py
+++ b/fastai2/callback/hook.py
@@ -154,7 +154,7 @@ def layer_info(learn):
 # Cell
 def _print_shapes(o, bs):
     if isinstance(o, torch.Size): return ' x '.join([str(bs)] + [str(t) for t in o[1:]])
-    else: return [_print_shapes(x, bs) for x in o]
+    else: return str([_print_shapes(x, bs) for x in o])
 
 # Cell
 @patch
@@ -173,7 +173,7 @@ def summary(self:Learner):
         if sz is None: continue
         ps += np
         if trn: trn_ps += np
-        res += f"{typ:<20} {_print_shapes(sz, bs):<20} {np:<10,} {str(trn):<10}\n"
+        res += f"{typ:<20} {_print_shapes(sz, bs)[:19]:<20} {np:<10,} {str(trn):<10}\n"
         res += "_" * n + "\n"
     res += f"\nTotal params: {ps:,}\n"
     res += f"Total trainable params: {trn_ps:,}\n"

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -1036,7 +1036,7 @@
     "#export\n",
     "def _print_shapes(o, bs):\n",
     "    if isinstance(o, torch.Size): return ' x '.join([str(bs)] + [str(t) for t in o[1:]])\n",
-    "    else: return [_print_shapes(x, bs) for x in o]"
+    "    else: return str([_print_shapes(x, bs) for x in o])"
    ]
   },
   {
@@ -1073,7 +1073,7 @@
     "        if sz is None: continue\n",
     "        ps += np\n",
     "        if trn: trn_ps += np\n",
-    "        res += f\"{typ:<20} {_print_shapes(sz, bs):<20} {np:<10,} {str(trn):<10}\\n\"\n",
+    "        res += f\"{typ:<20} {_print_shapes(sz, bs)[:19]:<20} {np:<10,} {str(trn):<10}\\n\"\n",
     "        res += \"_\" * n + \"\\n\"\n",
     "    res += f\"\\nTotal params: {ps:,}\\n\"\n",
     "    res += f\"Total trainable params: {trn_ps:,}\\n\"\n",
@@ -1132,6 +1132,51 @@
     "learn.create_opt()\n",
     "learn.model=m\n",
     "learn.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_NOutModel (Input shape: ['16 x 1'])\n",
+       "================================================================\n",
+       "Layer (type)         Output Shape         Param #    Trainable \n",
+       "================================================================\n",
+       "_NOutModel           ['16 x 16 x 256', '  0          False     \n",
+       "________________________________________________________________\n",
+       "\n",
+       "Total params: 0\n",
+       "Total trainable params: 0\n",
+       "Total non-trainable params: 0\n",
+       "\n",
+       "Optimizer used: functools.partial(<function SGD at 0x7f723046bb70>, mom=0.9)\n",
+       "Loss function: FlattenedLoss of MSELoss()\n",
+       "\n",
+       "Callbacks:\n",
+       "  - TrainEvalCallback\n",
+       "  - Recorder"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test for multiple output\n",
+    "class _NOutModel(nn.Module):\n",
+    "    def forward(self, x1):\n",
+    "        seq_len, bs, hid_size = 50, 16, 256\n",
+    "        num_layer = 1\n",
+    "        return torch.randn((seq_len, bs, hid_size)), torch.randn((num_layer, bs, hid_size))\n",
+    "m = _NOutModel()\n",
+    "learn = synth_learner()\n",
+    "learn.model = m\n",
+    "learn.summary() # Output Shape should be (50, 16, 256), (1, 16, 256)"
    ]
   },
   {


### PR DESCRIPTION
I found this bug when I tried to print the summary from model that includes nn.GRU(). It would throw error: `TypeError: unsupported format string passed to list.__format__ ` 

Dig into the code and I find that _print_shapes() will produce list of string for multiple outputs but this formated string f'{_print_shapes(sz, bs):<20}' in summary() needs a single string. 
Fix it by just let _print_shapes() return string and limit its length for display.
Also add a test that check it will not break when the model has multiple outputs.

When I tried to fix this bug, I found another issue. If the output batch size is not at first dimension like nn.GRU() by default, it will return a wrong size. No good idea for solving this.