### PR TITLE
Fixed editable install command to work universally with most shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 -->
 
 # Welcome to fastai v2
-
 > NB: This is still in early development. Use v1 unless you want to contribute to the next version of fastai
 
 
@@ -30,7 +29,7 @@ Or you can use an editable install (which is probably the best approach at the m
 ``` 
 git clone https://github.com/fastai/fastai2
 cd fastai2
-pip install -e .[dev]
+pip install -e ".[dev]"
 ``` 
 You should also use an editable install of [`fastcore`](https://github.com/fastai/fastcore) to go with it.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@ conda env create -f environment.yml
 
 <pre><code>git clone https://github.com/fastai/fastai2
 cd fastai2
-pip install -e .[dev]</code></pre>
+pip install -e ".[dev]"</code></pre>
 <p>You should also use an editable install of <code>fastcore</code> to go with it.</p>
 <p>To use <code>fastai2.medical.imaging</code> you'll also need to:</p>
 <div class="highlight"><pre><span></span>conda install pyarrow

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -34,7 +34,7 @@
     "``` \n",
     "git clone https://github.com/fastai/fastai2\n",
     "cd fastai2\n",
-    "pip install -e .[dev]\n",
+    "pip install -e \".[dev]\"\n",
     "``` \n",
     "You should also use an editable install of [`fastcore`](https://github.com/fastai/fastcore) to go with it.\n",
     "\n",


### PR DESCRIPTION
The existing command in the README for an editable install is: `pip install -e .[dev]`.
This does not work in the `zsh` shell. And since MacOS is now defaulting to `zsh` it becomes important for it to work with it as well.

Changing it to: `pip install -e ".[dev]"` makes it work with *both* `bash` and `zsh` (on ubuntu, macOS *and* Windows).

This GitHub issue adds more light into the issue and it's potential solutions: https://github.com/mu-editor/mu/issues/852. 
This comment concludes that adding double quotes is a universal solution for most platforms and shells: https://github.com/mu-editor/mu/issues/852#issuecomment-499870171

(P.S.: This is my 2nd PR on GitHub... apologies if I have violated any *recommended* ways to make a PR 😅)