### PR TITLE
fix distributed training after DataLoader change (device parameter)

### DIFF
--- a/fastai2/distributed.py
+++ b/fastai2/distributed.py
@@ -78,7 +78,7 @@ class DistributedDL(TfmdDL):
     @classmethod
     def from_dl(cls, dl, rank, world_size, **kwargs):
         cur_kwargs = dict(num_workers=dl.fake_l.num_workers, pin_memory=dl.pin_memory, timeout=dl.timeout,
-                          bs=dl.bs, shuffle=dl.shuffle, drop_last=dl.drop_last, indexed=dl.indexed)
+                          bs=dl.bs, shuffle=dl.shuffle, drop_last=dl.drop_last, indexed=dl.indexed, device=dl.device)
         cur_kwargs.update({n: getattr(dl, n) for n in cls._methods if n not in "get_idxs sample shuffle_fn create_item".split()})
         return cls(dl.dataset, rank, world_size, **merge(cur_kwargs, kwargs))
 
@@ -99,8 +99,8 @@ class DistributedTrainer(Callback):
     def begin_epoch(self):
         for dl in self.dls: dl.set_epoch(self.epoch)
 
-    def begin_train(self):    self.dl = self._wrap_dl(self.dl)
-    def begin_validate(self): self.dl = self._wrap_dl(self.dl)
+    def begin_train(self):    self.learn.dl = self._wrap_dl(self.learn.dl)
+    def begin_validate(self): self.learn.dl = self._wrap_dl(self.learn.dl)
 
     def after_fit(self):
         self.learn.model = self.learn.model.module

--- a/nbs/20a_distributed.ipynb
+++ b/nbs/20a_distributed.ipynb
@@ -184,7 +184,7 @@
     "    @classmethod\n",
     "    def from_dl(cls, dl, rank, world_size, **kwargs):\n",
     "        cur_kwargs = dict(num_workers=dl.fake_l.num_workers, pin_memory=dl.pin_memory, timeout=dl.timeout,\n",
-    "                          bs=dl.bs, shuffle=dl.shuffle, drop_last=dl.drop_last, indexed=dl.indexed)\n",
+    "                          bs=dl.bs, shuffle=dl.shuffle, drop_last=dl.drop_last, indexed=dl.indexed, device=dl.device)\n",
     "        cur_kwargs.update({n: getattr(dl, n) for n in cls._methods if n not in \"get_idxs sample shuffle_fn create_item\".split()})\n",
     "        return cls(dl.dataset, rank, world_size, **merge(cur_kwargs, kwargs))"
    ]
@@ -240,8 +240,8 @@
     "    def begin_epoch(self):\n",
     "        for dl in self.dls: dl.set_epoch(self.epoch)\n",
     "\n",
-    "    def begin_train(self):    self.dl = self._wrap_dl(self.dl)\n",
-    "    def begin_validate(self): self.dl = self._wrap_dl(self.dl)\n",
+    "    def begin_train(self):    self.learn.dl = self._wrap_dl(self.learn.dl)\n",
+    "    def begin_validate(self): self.learn.dl = self._wrap_dl(self.learn.dl)\n",
     "\n",
     "    def after_fit(self):\n",
     "        self.learn.model = self.learn.model.module\n",


### PR DESCRIPTION
fixes the distributed training issue introduces with the change from a `Cuda` callback to a `device` parameter on DataLoader reported in #57 and [here](https://forums.fast.ai/t/distributed-training-fails/63102) in the forums.

The fix is simply passing the `device` parameter from the `DataLoader` to the `DistributedDL` when it is initialized.

Also fixes this error:
```
warn(f"You are setting an attribute ({name}) that also exists in the learner. Please be advised that you're not setting it in the learner but in the callback. Use `self.learn.{name}` if you would like to change it in the learner.")
/home/jaidmin/Software/Devel/forks/fastai2/fastai2/learner.py:30: UserWarning: You are setting an attribute (dl) that also exists in the learner. Please be advised that you're not setting it in the learner but in the callback. Use `self.learn.dl` if you would like to change it in the learner.
```
If this behavior is wanted, let me know and I'll change the PR