### PR TITLE
fix AWD_QRNN when bidir=True

### DIFF
--- a/fastai2/text/models/awdlstm.py
+++ b/fastai2/text/models/awdlstm.py
@@ -159,7 +159,7 @@ class AWD_QRNN(AWD_LSTM):
     "Same as an AWD-LSTM, but using QRNNs instead of LSTMs"
     def _one_rnn(self, n_in, n_out, bidir, weight_p, l):
         from .qrnn import QRNN
-        rnn = QRNN(n_in, n_out, 1, save_prev_x=True, zoneout=0, window=2 if l == 0 else 1, output_gate=True, bidirectional=bidir)
+        rnn = QRNN(n_in, n_out, 1, save_prev_x=(not bidir), zoneout=0, window=2 if l == 0 else 1, output_gate=True, bidirectional=bidir)
         rnn.layers[0].linear = WeightDropout(rnn.layers[0].linear, weight_p, layer_names='weight')
         return rnn
 

--- a/nbs/32_text.models.awdlstm.ipynb
+++ b/nbs/32_text.models.awdlstm.ipynb
@@ -397,7 +397,7 @@
     "    \"Same as an AWD-LSTM, but using QRNNs instead of LSTMs\"\n",
     "    def _one_rnn(self, n_in, n_out, bidir, weight_p, l):\n",
     "        from fastai2.text.models.qrnn import QRNN\n",
-    "        rnn = QRNN(n_in, n_out, 1, save_prev_x=True, zoneout=0, window=2 if l == 0 else 1, output_gate=True, bidirectional=bidir)\n",
+    "        rnn = QRNN(n_in, n_out, 1, save_prev_x=(not bidir), zoneout=0, window=2 if l == 0 else 1, output_gate=True, bidirectional=bidir)\n",
     "        rnn.layers[0].linear = WeightDropout(rnn.layers[0].linear, weight_p, layer_names='weight')\n",
     "        return rnn\n",
     "\n",
@@ -412,6 +412,32 @@
     "            return torch.cat([self.hidden[l], self.hidden[l].new_zeros(self.n_dir, bs-self.bs, nh)], dim=1)\n",
     "        if self.bs > bs: return self.hidden[l][:bs]\n",
     "        return self.hidden[l]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = AWD_QRNN(vocab_sz=10, emb_sz=20, n_hid=16, n_layers=2, bidir=False)\n",
+    "x = torch.randint(0, 10, (7,5))\n",
+    "y = model(x)\n",
+    "test_eq(y.shape, (7, 5, 20))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hide\n",
+    "# test bidir=True\n",
+    "model = AWD_QRNN(vocab_sz=10, emb_sz=20, n_hid=16, n_layers=2, bidir=True)\n",
+    "x = torch.randint(0, 10, (7,5))\n",
+    "y = model(x)\n",
+    "test_eq(y.shape, (7, 5, 20))"
    ]
   },
   {


### PR DESCRIPTION
Bug happened when I called `AWD_QRNN` with `bidir=True`, it would cause this error: `"Can't save the previous X with bidirectional."`

I think the problem is AWD_QRNN always use save_prev_x=True to call QRNN, no matter bidir is what.

Fix it by assign flip of bidir to save_prev_x and add 2 simple tests.