### PR TITLE
Upgrade torchvision: PIL version Issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,13 +6,13 @@ channels:
 dependencies:
 - jupyter
 - pytorch>=1.2.0,<1.4.0
-- torchvision<=0.4.2
+- torchvision>=0.5.0
 - matplotlib
 - pandas
 - requests
 - pyyaml
 - fastprogress>=0.1.22
-- pillow<=6.1
+- pillow
 - python>=3.6
 - pip
 - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - requests
 - pyyaml
 - fastprogress>=0.1.22
-- pillow
+- pillow<=6.1
 - python>=3.6
 - pip
 - scikit-learn


### PR DESCRIPTION
https://github.com/pytorch/vision/issues/1712

Recently PIL 7 removed `PILLOW_VERSION`. This affects `torchvision: 0.4.2` as described in the pytorch issue.

Alternative upgrade to `torchvision>=0.5.0`