### PR TITLE
WandbCallback: fix issues

### DIFF
--- a/fastai2/callback/wandb.py
+++ b/fastai2/callback/wandb.py
@@ -42,10 +42,8 @@ class WandbCallback(Callback):
             wandbRandom = random.Random(self.seed)  # For repeatability
             self.n_preds = min(self.n_preds, len(self.dls.valid_ds))
             idxs = wandbRandom.sample(range(len(self.dls.valid_ds)), self.n_preds)
-
-            items = [self.dls.valid_ds.items[i] for i in idxs]
-            test_tls = [tl._new(items, split_idx=1) for tl in self.dls.valid_ds.tls]
-            self.valid_dl = self.dls.valid.new(Datasets(tls=test_tls), bs=self.n_preds)
+            test_items = [self.dls.valid_ds.items[i] for i in idxs]
+            self.valid_dl = self.dls.test_dl(test_items)
 
     def after_batch(self):
         "Log hyper-parameters and training loss"

--- a/fastai2/callback/wandb.py
+++ b/fastai2/callback/wandb.py
@@ -65,7 +65,7 @@ class WandbCallback(Callback):
             preds = getattr(self.loss_func, 'activation', noop)(self.pred)
             out = getattr(self.loss_func, 'decodes', noop)(preds)
             x,y,its,outs = self.valid_dl.show_results(b, out, show=False, max_n=self.n_preds)
-            wandb.log({"Prediction Samples": wandb_process(x, y, its, outs)}, step=self._wandb_step)
+            wandb.log(wandb_process(x, y, its, outs), step=self._wandb_step)
         wandb.log({n:s for n,s in zip(self.recorder.metric_names, self.recorder.log) if n not in ['train_loss', 'epoch', 'time']}, step=self._wandb_step)
 
     def after_fit(self):
@@ -94,16 +94,16 @@ def wandb_process(x:TensorImage, y, samples, outs):
             ax = t.show(ctx=ax)
             res.append(wandb.Image(fig, caption=capt))
             plt.close(fig)
-    return res
+    return {"Prediction Samples": res}
 
 # Cell
 @typedispatch
 def wandb_process(x:TensorImage, y:(TensorCategory,TensorMultiCategory), samples, outs):
-    return [wandb.Image(s[0].permute(1,2,0), caption=f'Ground Truth: {s[1]}\nPrediction: {o[0]}')
-            for s,o in zip(samples,outs)]
+    return {"Prediction Samples": [wandb.Image(s[0].permute(1,2,0), caption=f'Ground Truth: {s[1]}\nPrediction: {o[0]}')
+            for s,o in zip(samples,outs)]}
 
 # Cell
 @typedispatch
 def wandb_process(x:TensorText, y:(TensorCategory,TensorMultiCategory), samples, outs):
     data = [[s[0], s[1], o[0]] for s,o in zip(samples,outs)]
-    return wandb.Table(data=data, columns=["Text", "Target", "Prediction"])
+    return {"Prediction Samples": wandb.Table(data=data, columns=["Text", "Target", "Prediction"])}

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -125,7 +125,7 @@
     "            preds = getattr(self.loss_func, 'activation', noop)(self.pred)\n",
     "            out = getattr(self.loss_func, 'decodes', noop)(preds)\n",
     "            x,y,its,outs = self.valid_dl.show_results(b, out, show=False, max_n=self.n_preds)\n",
-    "            wandb.log({\"Prediction Samples\": wandb_process(x, y, its, outs)}, step=self._wandb_step)\n",
+    "            wandb.log(wandb_process(x, y, its, outs), step=self._wandb_step)\n",
     "        wandb.log({n:s for n,s in zip(self.recorder.metric_names, self.recorder.log) if n not in ['train_loss', 'epoch', 'time']}, step=self._wandb_step)\n",
     "\n",
     "    def after_fit(self):\n",
@@ -193,7 +193,7 @@
     "            ax = t.show(ctx=ax)\n",
     "            res.append(wandb.Image(fig, caption=capt))\n",
     "            plt.close(fig)\n",
-    "    return res"
+    "    return {\"Prediction Samples\": res}"
    ]
   },
   {
@@ -205,8 +205,8 @@
     "#export\n",
     "@typedispatch\n",
     "def wandb_process(x:TensorImage, y:(TensorCategory,TensorMultiCategory), samples, outs):\n",
-    "    return [wandb.Image(s[0].permute(1,2,0), caption=f'Ground Truth: {s[1]}\\nPrediction: {o[0]}')\n",
-    "            for s,o in zip(samples,outs)]"
+    "    return {\"Prediction Samples\": [wandb.Image(s[0].permute(1,2,0), caption=f'Ground Truth: {s[1]}\\nPrediction: {o[0]}')\n",
+    "            for s,o in zip(samples,outs)]}"
    ]
   },
   {
@@ -219,7 +219,7 @@
     "@typedispatch\n",
     "def wandb_process(x:TensorText, y:(TensorCategory,TensorMultiCategory), samples, outs):\n",
     "    data = [[s[0], s[1], o[0]] for s,o in zip(samples,outs)]\n",
-    "    return wandb.Table(data=data, columns=[\"Text\", \"Target\", \"Prediction\"])"
+    "    return {\"Prediction Samples\": wandb.Table(data=data, columns=[\"Text\", \"Target\", \"Prediction\"])}"
    ]
   },
   {

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -102,10 +102,8 @@
     "            wandbRandom = random.Random(self.seed)  # For repeatability\n",
     "            self.n_preds = min(self.n_preds, len(self.dls.valid_ds))\n",
     "            idxs = wandbRandom.sample(range(len(self.dls.valid_ds)), self.n_preds)\n",
-    "\n",
-    "            items = [self.dls.valid_ds.items[i] for i in idxs]\n",
-    "            test_tls = [tl._new(items, split_idx=1) for tl in self.dls.valid_ds.tls]\n",
-    "            self.valid_dl = self.dls.valid.new(Datasets(tls=test_tls), bs=self.n_preds)\n",
+    "            test_items = [self.dls.valid_ds.items[i] for i in idxs]\n",
+    "            self.valid_dl = self.dls.test_dl(test_items)\n",
     "\n",
     "    def after_batch(self):\n",
     "        \"Log hyper-parameters and training loss\"\n",
@@ -265,11 +263,11 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7.6 64-bit ('fastai2': pipenv)",
    "language": "python",
-   "name": "python3"
+   "name": "python37664bitfastai2pipenv80825f375c9546baa11aaf1cbed21b4f"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR:

* fixes #70 
* allow logging any dict for more flexibility -> we can improve `wandb_process` later
  * log `best/worst predictions`
  * separate `inputs`, `labels`, `predictions` to display them separately or together. This also let us display evolution of predictions along time (this is what I'm currently doing)
  * allow custom `wandb_process` for users to log whatever they want