### PR TITLE
fix: DataBlock respect dl_type kwarg

### DIFF
--- a/fastai2/data/block.py
+++ b/fastai2/data/block.py
@@ -62,6 +62,7 @@ class DataBlock():
         self.default_batch_tfms = _merge_tfms(*blocks.attrgot('batch_tfms', L()))
         for b in blocks:
             if getattr(b, 'dl_type', None) is not None: self.dl_type = b.dl_type
+        if dl_type is not None: self.dl_type = dl_type
         self.dataloaders = delegates(self.dl_type.__init__)(self.dataloaders)
         self.dls_kwargs = merge(*blocks.attrgot('dls_kwargs', {}))
 

--- a/nbs/06_data.block.ipynb
+++ b/nbs/06_data.block.ipynb
@@ -189,6 +189,7 @@
     "        self.default_batch_tfms = _merge_tfms(*blocks.attrgot('batch_tfms', L()))\n",
     "        for b in blocks: \n",
     "            if getattr(b, 'dl_type', None) is not None: self.dl_type = b.dl_type\n",
+    "        if dl_type is not None: self.dl_type = dl_type\n",
     "        self.dataloaders = delegates(self.dl_type.__init__)(self.dataloaders)\n",
     "        self.dls_kwargs = merge(*blocks.attrgot('dls_kwargs', {}))\n",
     "        \n",


### PR DESCRIPTION
Looks like this was inadvertently removed in https://github.com/fastai/fastai2/commit/dcc7e1bfa7170700143127e56d8dae8e97ef8177#diff-3fec432759d383a373137d69c9ac4c72L58?