### PR TITLE
fix bbox coordinates convention

### DIFF
--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -928,7 +928,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Bounding boxes are expected to come as tuple with an array/tensor of shape `(n,4)` or as a list of lists with four elements adn a list of corresponding labels. Unless you change the defaults in `BBoxScaler` (see later on), coordinates for each bounding box should go from 0 to height/width, with the following convetion: top, left, bottom, right.\n",
+    "Bounding boxes are expected to come as tuple with an array/tensor of shape `(n,4)` or as a list of lists with four elements adn a list of corresponding labels. Unless you change the defaults in `BBoxScaler` (see later on), coordinates for each bounding box should go from 0 to height/width, with the following convetion: x1, y1, x2, y2.\n",
     "\n",
     "> Note: We use the same convention as for points with y axis being before x."
    ]


### PR DESCRIPTION
I noticed that the convention [changed](https://github.com/fastai/fastai2/blob/master/fastai2/vision/core.py#L175) from v1 to x1,y1,x2,y2.
