### PR TITLE
Show rules to Tokenizer calss in .from_df

### DIFF
--- a/fastai2/text/core.py
+++ b/fastai2/text/core.py
@@ -255,7 +255,7 @@ class Tokenizer(Transform):
     @classmethod
     @delegates(tokenize_df, keep=True)
     def from_df(cls, text_cols, tok_func=SpacyTokenizer, rules=None, **kwargs):
-        res = cls(get_tokenizer(tok_func, rules=rules, **kwargs), mode='df')
+        res = cls(get_tokenizer(tok_func, **kwargs), rules=rules, mode='df')
         res.text_cols,res.kwargs,res.train_setup = text_cols,merge({'tok_func': tok_func}, kwargs),False
         return res
 

--- a/nbs/30_text.core.ipynb
+++ b/nbs/30_text.core.ipynb
@@ -914,7 +914,7 @@
     "    @classmethod\n",
     "    @delegates(tokenize_df, keep=True)\n",
     "    def from_df(cls, text_cols, tok_func=SpacyTokenizer, rules=None, **kwargs):\n",
-    "        res = cls(get_tokenizer(tok_func, rules=rules, **kwargs), mode='df')\n",
+    "        res = cls(get_tokenizer(tok_func, **kwargs), rules=rules, mode='df')\n",
     "        res.text_cols,res.kwargs,res.train_setup = text_cols,merge({'tok_func': tok_func}, kwargs),False\n",
     "        return res\n",
     "\n",


### PR DESCRIPTION
When calling Tokenizer.from_df, rules=rules lies inside the call to get_tokenizer and so the Tokenizer class defaults to the default fastai rules as the class cannot see any fules added in .from_df()