### PR TITLE
fix datablock.summary device error if normalize is a batch_tfm

### DIFF
--- a/fastai2/data/block.py
+++ b/fastai2/data/block.py
@@ -175,5 +175,6 @@ def summary(self: DataBlock, source, bs=4, **kwargs):
 
     if len([f for f in dls.train.after_batch.fs if f.name != 'noop'])!=0:
         print("\nApplying batch_tfms to the batch built")
+        b = to_device(b, dls.device)
         b = _apply_pipeline(dls.train.after_batch, b)
     else: print("\nNo batch_tfms to apply")

--- a/nbs/06_data.block.ipynb
+++ b/nbs/06_data.block.ipynb
@@ -248,7 +248,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DataBlock.datasets\" class=\"doc_header\"><code>DataBlock.datasets</code><a href=\"__main__.py#L40\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DataBlock.datasets\" class=\"doc_header\"><code>DataBlock.datasets</code><a href=\"__main__.py#L42\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DataBlock.datasets</code>(**`source`**, **`verbose`**=*`False`*)\n",
        "\n",
@@ -274,9 +274,9 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DataBlock.dataloaders\" class=\"doc_header\"><code>DataBlock.dataloaders</code><a href=\"__main__.py#L47\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DataBlock.dataloaders\" class=\"doc_header\"><code>DataBlock.dataloaders</code><a href=\"__main__.py#L49\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>DataBlock.dataloaders</code>(**`source`**, **`path`**=*`'.'`*, **`verbose`**=*`False`*)\n",
+       "> <code>DataBlock.dataloaders</code>(**`source`**, **`path`**=*`'.'`*, **`verbose`**=*`False`*, **`bs`**=*`64`*, **`shuffle`**=*`False`*, **`num_workers`**=*`None`*, **`do_setup`**=*`True`*, **`pin_memory`**=*`False`*, **`timeout`**=*`0`*, **`batch_size`**=*`None`*, **`drop_last`**=*`False`*, **`indexed`**=*`None`*, **`n`**=*`None`*, **`device`**=*`None`*, **`wif`**=*`None`*, **`before_iter`**=*`None`*, **`after_item`**=*`None`*, **`before_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_iter`**=*`None`*, **`create_batches`**=*`None`*, **`create_item`**=*`None`*, **`create_batch`**=*`None`*, **`retain`**=*`None`*, **`get_idxs`**=*`None`*, **`sample`**=*`None`*, **`shuffle_fn`**=*`None`*, **`do_batch`**=*`None`*)\n",
        "\n",
        "Create a [`DataLoaders`](/data.core#DataLoaders) object from `source`"
       ],
@@ -344,7 +344,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHsAAACLCAYAAABBVeZmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAE3klEQVR4nO2dTyh0axzHf4/srpAkpRQJCTvkioQsbBSykO4srGSDsvRnIVvq9a+s2Chyy07dEq5YKSlFKVnpXlLcu7DAuav3NL/nvWbMOzPnnJnv91PqfJs508On3/l5znPOGeM4jhAMMvweAPEOygaCsoGgbCAoGwjKBoKygYCSbYz51/p5N8Z883tcXpHp9wC8xHGcrO/bxphfROQvEdn2b0TeAlXZFn0i8reI/On3QLwCWXZIRDYcoPPFBuh3dTHGFIvIrYiUOY5z6/d4vAK1sn8TkWMk0SLYstf9HoTXwB3GjTG/isgfIlLoOM4/fo/HSxArOyQiv6OJFgGsbGQQKxsWygaCsoGgbCAoG4hoq178Vz31MJ+9wMoGgrKBoGwgKBsIygaCsoGgbCAoGwjKBoKygaBsICgbCMoGgrKBoGwgKBsIygaCsoGgbCAoGwjKBoKygaBsICgbCMoGgrKBSNmH3r29val8fn6ucn19vcoFBQXu9sTEhHrt+vpa5bW1NZXb2tpU7urqim2wFrW1tSq3t7e72xkZyas/VjYQlA0EZQMR7QE6gbll9/n5WeWRkRGVNzc3vRxOQnl4eHC38/Ly4v043rJLKBsKygYisPPs19dXlZubm1W+vLyM6fNmZmbc7c7OzojvXVxcVPn09FTl29v4nm+bn5+vcmamNxpY2UBQNhCUDURgerbdo4eHh1WO1qON0dPLoaEhlcfGxtztrKwsiURDQ4PKLy8vKu/v76vc29sb8fNsenp6VM7Ozo5p/5+FlQ0EZQNB2UAE5tz43d2dyqWlpTHt39TUpPLR0VHcY/rOwcGByoODgyrf399H3L+oqEjlw8NDlUtKSn5+cD/Cc+OEsqGgbCACM8/Ozc1VORQKqby+rr+GK3zeLCIyOzubnIGJyO7ursrRerTN1taWygnu0V+GlQ0EZQNB2UAEZp5t8/HxobJ9nbh9fXU8a8L232B6elrlubm5iO+3mZycVHlqakrlZF4bLpxnExHKhiKwh/Fk8v7+rrJ9arWjoyPi/vZyaktLi8r2EqjH8DBOKBsKygYCsmff3NyoXFFREdP+ZWVlKtu3/PoMezahbCgoG4jALHEmm8fHR3d7ZWUlpn2Li4tVPj4+TsiYvIaVDQRlA0HZQKTtPNteEh0YGHC3d3Z2Iu5rXzZk9+jCwsI4R5dUOM8mlA0FZQORNvNs+zKm8fFxlaP16XD29vZUDniP/jKsbCAoGwjKBiJtevb29rbKS0tLn77XPte9sLCgcqy3C6cKrGwgKBsIygYiZXu23aPDz31Ho66uTuXu7u6EjCnosLKBoGwgKBuIlFnPvrq6UrmxsVFl+5GTNqOjo+62fUut/YiPFIfr2YSyoaBsIALbs+1HTre2tqr89PQUcf+amhqVwx9JmWY92oY9m1A2FJQNRGB6dvhXFIqIVFdXqxx+r9b/UVlZqfLJyYnKOTk5cYwupWDPJpQNRWCWOJeXl1WOdtiuqqpSeXV1VWWgw/aXYWUDQdlAUDYQvvXss7Mzlefn52Pav6+vT2X723/Ij7CygaBsICgbCN96dnl5ucr2oy0uLi5U3tjYULm/vz85A0tjWNlAUDYQlA1EYJY4ScLgEiehbCgoG4ho8+xPj/8k9WBlA0HZQFA2EJQNBGUDQdlA/AdDRSN/yb0OvgAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHsAAACLCAYAAABBVeZmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAEtklEQVR4nO2dTyhsfRjHn9/Nwv+sZCEkC0oKG91sWEhk90qSezdK5N9GEUmWiHQ3yp9yd1Jvsn1Z8N4UZSHCyt0iSd2bJJy7uXe6zylnzMyZc+bM9/spNd/mzG8ePj3zzJzjzDGWZQnB4IPfBRDvoGwgKBsIygaCsoGgbCAoGwgo2caYn7afF2PMF7/r8ooUvwvwEsuyMv/cNsZkiMi1iGz4V5G3QHW2jX9E5EZE/ve7EK9Alv1ZRL5aQPuLDdDvGsIYUyAi30WkxLKs737X4xWonf1JRL4hiRbBlr3mdxFeA/cyboz5KCL/iUieZVk//K7HSxA7+7OI/IsmWgSws5FB7GxYKBsIygaCsoGgbCDCHfXiW/XgYd66g50NBGUDQdlAUDYQlA0EZQNB2UBQNhCUDQRlA0HZQFA2EJQNBGUDQdlAUDYQlA0EZQNB2UBQNhCUDQRlAwH1BTpvsbe3p/LAwIDKx8fHKre2tqq8saG/g2dra0vllpaWWEt0BXY2EJQNBGUDEe5k/KQ5/efvuWyfyScnJyrH+gUF/f39Ki8sLMS0XoTw9B9C2VBQNhBJO7MXFxdV7uvrC91+fX2N63Pn5uaqfHV1Fdfns8GZTSgbCsoGIrD7xu/u7lRuaGhQ2b4/22lO5+XlqdzV1eX43Jubmyqfnp46bp8osLOBoGwgKBuIwMzsg4MDlZubm1W2z3AnxsbGVB4dHVU5PT3dce25uTnH9evr699di5ews4GgbCAoG4iEndnz8/MqT09PqxxuRhcUFKg8PDwcut3d3a3uS0lx/jPMzMyo/PDw4Lh9e3u74/1+wc4GgrKBoGwgfJvZt7e3Kq+urqo8Pj6u8vPzs+N6U1NTKtv/zyw7OzvSEkPc399H/dhEgp0NBGUDQdlA+Dazd3Z2VB4ZGXHcvqioSOWhoSGVe3t7VQ732dkJ+/uJ9fV1x+3T0tJULiwsjPq54wk7GwjKBiJhd5fa2d7eVrm4uNi1tR8fH1W2H/IM99GrsbFR5YqKCncKcxl2NhCUDQRlA+HbzG5qalK5s7NT5fLycpXthyzd5Pr6WuWVlZWIHt/T0+NmOXGDnQ0EZQNB2UD4NrOzsrJUXltb86kSkeXl5Yi2z8/PV7mmpsbNcuIGOxsIygaCsoEIzL5xN7GfYru0tBTR4zMyMlTOzMyMuSYvYGcDQdlAUDYQkDN7cnJS5ZubG8ftU1NTVZ6YmHC7JE9gZwNB2UBQNhBJO7Ofnp5UPj8/D93e39+PaK3Z2VmVE/WU3HCws4GgbCAoG4ikndkXFxcqV1ZWRr1WVVVVrOUkBOxsICgbCMoGImlndrjTbJ2orq5WubS0NNZyEgJ2NhCUDQRlA5E0l3q6vLxUuba2VmWnyy2VlJSofHh4qHJOTk6M1XkKL/VEKBsKygYisJ+zX15eVG5ra1M5kksiDg4OqhywGf1u2NlAUDYQgXkZt19xz/71VUdHR+9eq6ysTOWOjo7oCwsQ7GwgKBsIygYiMLtLd3d3Va6rq4t6rbOzM5WT5RDmb7i7lFA2FJQNRGBmNnk3nNmEsqGgbCAoGwjKBoKygaBsIMIdz37zMxsJHuxsICgbCMoGgrKBoGwgKBuIX2IkA3PEYWLsAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 144x144 with 1 Axes>"
       ]
@@ -491,6 +491,7 @@
     "    \n",
     "    if len([f for f in dls.train.after_batch.fs if f.name != 'noop'])!=0:\n",
     "        print(\"\\nApplying batch_tfms to the batch built\")\n",
+    "        b = to_device(b, dls.device)\n",
     "        b = _apply_pipeline(dls.train.after_batch, b)\n",
     "    else: print(\"\\nNo batch_tfms to apply\")"
    ]


### PR DESCRIPTION
This fixes an issue with `DataBlock.summary` which was introduced with the removal of the `Cuda` transform. 
It's simply fixed by moving the batch to the device that the dataloader (and therefore the transforms expect). 
Another way would be to make Normalize agnostic and just work with the input regardless on what device its on.

Here is the issue when trying to call `summary` (the issue appears if there is a `Normalize` in the `batch_tfms` transforms)

```Setting-up type transforms pipelines
Collecting items from /home/jaidmin/.fastai/data/mnist_tiny
Found 1428 items
2 datasets of sizes 709,699
Setting up Pipeline: PILBase.create
Setting up Pipeline: parent_label -> Categorize

Building one sample
  Pipeline: PILBase.create
    starting from
      /home/jaidmin/.fastai/data/mnist_tiny/train/7/8717.png
    applying PILBase.create gives
      PILImageBW mode=L size=28x28
  Pipeline: parent_label -> Categorize
    starting from
      /home/jaidmin/.fastai/data/mnist_tiny/train/7/8717.png
    applying parent_label gives
      7
    applying Categorize gives
      TensorCategory(1)

Final sample: (PILImageBW mode=L size=28x28, TensorCategory(1))


Setting up after_item: Pipeline: ToTensor
Setting up before_batch: Pipeline: 
Setting up after_batch: Pipeline: IntToFloatTensor -> Normalize

Building one batch
Applying item_tfms to the first sample:
  Pipeline: ToTensor
    starting from
      (PILImageBW mode=L size=28x28, TensorCategory(1))
    applying ToTensor gives
      (TensorImageBW of size 1x28x28, TensorCategory(1))

Adding the next 3 samples

No before_batch transform to apply

Collating items in a batch

Applying batch_tfms to the batch built
  Pipeline: IntToFloatTensor -> Normalize
    starting from
      (TensorImageBW of size 4x1x28x28, TensorCategory([1, 1, 1, 1]))
    applying IntToFloatTensor gives
      (TensorImageBW of size 4x1x28x28, TensorCategory([1, 1, 1, 1]))
    applying Normalize failed.

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-26-e3fa48cc8be2> in <module>
----> 1  mnist.summary(untar_data(URLs.MNIST_TINY))

<ipython-input-25-d97181d6e621> in summary(self, source, bs, **kwargs)
 37     if len([f for f in dls.train.after_batch.fs if f.name != 'noop'])!=0:
 38         print("\nApplying batch_tfms to the batch built")
---> 39  b = _apply_pipeline(dls.train.after_batch, b)
 40     else: print("\nNo batch_tfms to apply")

<ipython-input-21-c3abd94a686a> in _apply_pipeline(p, x)
 9         except Exception as e:
 10             print(f"    applying {name} failed.")
---> 11  raise e
 12     return x

<ipython-input-21-c3abd94a686a> in _apply_pipeline(p, x)
 5         name = f.name
 6         try:
----> 7  x = f(x)
 8             if name != "noop": print(f"    applying {name} gives\n      {_short_repr(x)}")
 9         except Exception as e:

~/Software/Devel/fastcore/fastcore/transform.py in __call__(self, x, **kwargs)
 70     @property
 71     def name(self): return getattr(self, '_name', _get_name(self))
---> 72  def __call__(self, x, **kwargs): return self._call('encodes', x, **kwargs)
 73     def decode  (self, x, **kwargs): return self._call('decodes', x, **kwargs)
 74     def __repr__(self): return f'{self.name}: {self.encodes} {self.decodes}'

~/Software/Devel/fastcore/fastcore/transform.py in _call(self, fn, x, split_idx, **kwargs)
 82         f = getattr(self, fn)
 83         if not _is_tuple(x): return self._do_call(f, x, **kwargs)
---> 84  res = tuple(self._do_call(f, x_, **kwargs) for x_ in x)
 85         return retain_type(res, x)
 86 

~/Software/Devel/fastcore/fastcore/transform.py in <genexpr>(.0)
 82         f = getattr(self, fn)
 83         if not _is_tuple(x): return self._do_call(f, x, **kwargs)
---> 84  res = tuple(self._do_call(f, x_, **kwargs) for x_ in x)
 85         return retain_type(res, x)
 86 

~/Software/Devel/fastcore/fastcore/transform.py in _do_call(self, f, x, **kwargs)
 86 
 87     def _do_call(self, f, x, **kwargs):
---> 88  return x if f is None else retain_type(f(x, **kwargs), x, f.returns_none(x))
 89 
 90 add_docs(Transform, decode="Delegate to `decodes` to undo transform", setup="Delegate to `setups` to set up transform")

~/Software/Devel/fastcore/fastcore/dispatch.py in __call__(self, *args, **kwargs)
 96         if not f: return args[0]
 97         if self.inst is not None: f = MethodType(f, self.inst)
---> 98  return f(*args, **kwargs)
 99 
 100     def __get__(self, inst, owner):

~/Software/Devel/fastai2/fastai2/data/transforms.py in encodes(self, x)
 303             self.mean,self.std = x.mean(self.axes, keepdim=True),x.std(self.axes, keepdim=True)+1e-7
 304 
--> 305  def encodes(self, x:TensorImage): return (x-self.mean) / self.std
 306     def decodes(self, x:TensorImage):
 307         f = to_cpu if x.device.type=='cpu' else noop

~/Software/Devel/fastai2/fastai2/torch_core.py in _f(self, *args, **kwargs)
 270         def _f(self, *args, **kwargs):
 271             cls = self.__class__
--> 272  res = getattr(super(TensorBase, self), fn)(*args, **kwargs)
 273             return retain_type(res, self)
 274         return _f

RuntimeError: expected device cpu but got device cuda:0```