### PR TITLE
fix AWD_LSTM not contiguous bug

### DIFF
--- a/fastai2/text/models/awdlstm.py
+++ b/fastai2/text/models/awdlstm.py
@@ -123,7 +123,7 @@ class AWD_LSTM(Module):
         if self.bs < bs:
             nh = (self.n_hid if l != self.n_layers - 1 else self.emb_sz) // self.n_dir
             return tuple(torch.cat([h, h.new_zeros(self.n_dir, bs-self.bs, nh)], dim=1) for h in self.hidden[l])
-        if self.bs > bs: return (self.hidden[l][0][:,:bs], self.hidden[l][1][:,:bs])
+        if self.bs > bs: return (self.hidden[l][0][:,:bs].contiguous(), self.hidden[l][1][:,:bs].contiguous())
         return self.hidden[l]
 
     def reset(self):

--- a/nbs/32_text.models.awdlstm.ipynb
+++ b/nbs/32_text.models.awdlstm.ipynb
@@ -266,7 +266,7 @@
     "        if self.bs < bs:\n",
     "            nh = (self.n_hid if l != self.n_layers - 1 else self.emb_sz) // self.n_dir\n",
     "            return tuple(torch.cat([h, h.new_zeros(self.n_dir, bs-self.bs, nh)], dim=1) for h in self.hidden[l])\n",
-    "        if self.bs > bs: return (self.hidden[l][0][:,:bs], self.hidden[l][1][:,:bs])\n",
+    "        if self.bs > bs: return (self.hidden[l][0][:,:bs].contiguous(), self.hidden[l][1][:,:bs].contiguous())\n",
     "        return self.hidden[l]\n",
     "\n",
     "    def reset(self):\n",
@@ -317,6 +317,23 @@
     "x = torch.randint(0, 100, (6,5))\n",
     "r = tst(x)\n",
     "test_eq(tst.bs, 6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hide\n",
+    "# cuda\n",
+    "tst = AWD_LSTM(100, 20, 10, 2, bidir=True).to('cuda')\n",
+    "tst.reset()\n",
+    "x = torch.randint(0, 100, (10,5)).to('cuda')\n",
+    "r = tst(x)\n",
+    "\n",
+    "x = torch.randint(0, 100, (6,5), device='cuda')\n",
+    "r = tst(x)"
    ]
   },
   {


### PR DESCRIPTION
Error: `rnn: hx is not contiguous`

This error happens when 
1. bidir=True 
2. bs decrease
3. run on gpu

The 1 and 2 cause `self.hidden[l][0][:,:bs]` be not contiguous, and with 3 the error happens.

Fix it by adding contiguous() after self.hidden[l][0][:,:bs] and add a test that can reproduce this error with cuda flag.