### PR TITLE
Small fix to 10_tutorial.pets notebook

### DIFF
--- a/nbs/10_tutorial.pets.ipynb
+++ b/nbs/10_tutorial.pets.ipynb
@@ -945,7 +945,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you create a `Datasource`, you can pass along `splits` indices that represent the split between train and validation set (there can be multiple validation sets) on top of the items and tfms."
+    "When you create a `Datasets` object, you can pass along `splits` indices that represent the split between train and validation set (there can be multiple validation sets) on top of the items and tfms."
    ]
   },
   {


### PR DESCRIPTION
There was still one reference to `Datasource`, so I changed it to use the new name `Datasets`.