### PR TITLE
Fix lesson3-imdb

### DIFF
--- a/nbs/course/lesson3-imdb.ipynb
+++ b/nbs/course/lesson3-imdb.ipynb
@@ -756,7 +756,7 @@
     }
    ],
    "source": [
-    "learn.recorder.plot(skip_end=15)"
+    "learn.recorder.plot_lr_find(skip_end=15)"
    ]
   },
   {

--- a/nbs/course/lesson3-imdb.ipynb
+++ b/nbs/course/lesson3-imdb.ipynb
@@ -260,7 +260,7 @@
     }
    ],
    "source": [
-    "dbunch_lm = TextDataLoaders.from_df(df, text_col='text', label_col='label', path=path, is_lm=True)"
+    "dbunch_lm = TextDataLoaders.from_df(df, text_col='text', label_col='label', path=path, is_lm=True, valid_col='is_valid')"
    ]
   },
   {


### PR DESCRIPTION
Two cahnges:

**1: Make use of `is_valid` column of original dataframe**

![image](https://user-images.githubusercontent.com/8177565/76858471-ced91c80-6857-11ea-8231-20e900d7db9e.png)
from:
```python
dbunch_lm = TextDataLoaders.from_df(df, text_col='text', label_col='label', 
                                    path=path, is_lm=True)
```
to:
```python
dbunch_lm = TextDataLoaders.from_df(df, text_col='text', label_col='label', 
                                    path=path, is_lm=True, valid_col='is_valid')
```
Actually the count of validation items does not change (the default valid_pct=20% that takes to 200 items), but no more sampling randomness is present:
```Python
df.is_valid.value_counts()

False    800
True     200
```

**2: updated method name to `plot_lr_find``**
Renamed method to new convention, from:
```Python
learn.recorder.plot(skip_end=15)
```
to:
```Python
learn.recorder.plot_lr_find(skip_end=15)
```


