### PR TITLE
Fix at learn.destroy()

### DIFF
--- a/nbs/course/lesson3-camvid.ipynb
+++ b/nbs/course/lesson3-camvid.ipynb
@@ -1112,7 +1112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn.destroy()\n",
+    "#learn.destroy()\n",
     "\n",
     "size = src_size\n",
     "\n",


### PR DESCRIPTION
Commented "learn.destroy()" in lesson3-camvid.ipynb as "del learn" already exists and Learner does not have attribute called 'destroy'
Please refer the below screenshots for reference:
![image](https://user-images.githubusercontent.com/62723901/78185528-d6401e80-7430-11ea-8471-8f47faae0c0e.png)

![image](https://user-images.githubusercontent.com/62723901/78185076-24085700-7430-11ea-9e8e-d9a2896bced6.png)
