### PR TITLE
AttributeError: 'Model3' object has no attribute 'f'

### DIFF
--- a/nbs/course/lesson7-human-numbers.ipynb
+++ b/nbs/course/lesson7-human-numbers.ipynb
@@ -1021,7 +1021,7 @@
     "        res = self.h_o(res)\n",
     "        return res\n",
     "    \n",
-    "    def reset(self): self.f.h = torch.zeros(bs, nh).cuda()"
+    "    def reset(self): self.h = torch.zeros(bs, nh).cuda()"
    ]
   },
   {


### PR DESCRIPTION
Fix for the below error in lessson7-human-numbers.py

![image](https://user-images.githubusercontent.com/62723901/78514365-89cd4980-7776-11ea-98b0-fd6381e3277b.png)

Fix: def reset(self): self.h = torch.zeros(bs, nh).cuda()