### PR TITLE
GitHub Actions: Update checkout and setup-python, use Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.8'
         architecture: 'x64'
     - name: Install the library
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
         python-version: '3.6'


### PR DESCRIPTION
A bit of GitHub Actions maintenance.
 - Update to [checkout](https://github.com/actions/checkout) v2 (performs faster)
 - Update to [setup-python](https://github.com/actions/setup-python) v2
 - Use Python 3.8 (latest stable version)