### PR TITLE
Fix CutMix lerp weight bug

### DIFF
--- a/fastai2/callback/cutmix.py
+++ b/fastai2/callback/cutmix.py
@@ -28,7 +28,7 @@ class CutMix(Callback):
         nx_dims = len(self.x.size())
         x1, y1, x2, y2 = self.rand_bbox(W, H, self.lam)
         self.learn.xb[0][:, :, x1:x2, y1:y2] = xb1[0][:, :, x1:x2, y1:y2]
-        self.lam = (1 - ((x2-x1)*(y2-y1))/(W*H)).type(torch.float)
+        self.lam = (1 - ((x2-x1)*(y2-y1))/float(W*H)).item()
 
         if not self.stack_y:
             ny_dims = len(self.y.size())

--- a/nbs/74_callback.cutmix.ipynb
+++ b/nbs/74_callback.cutmix.ipynb
@@ -67,7 +67,7 @@
     "        nx_dims = len(self.x.size())\n",
     "        x1, y1, x2, y2 = self.rand_bbox(W, H, self.lam)\n",
     "        self.learn.xb[0][:, :, x1:x2, y1:y2] = xb1[0][:, :, x1:x2, y1:y2]\n",
-    "        self.lam = (1 - ((x2-x1)*(y2-y1))/(W*H)).type(torch.float)\n",
+    "        self.lam = (1 - ((x2-x1)*(y2-y1))/float(W*H)).item()\n",
     "        \n",
     "        if not self.stack_y:\n",
     "            ny_dims = len(self.y.size())\n",


### PR DESCRIPTION
x1,y1,x2,y2,w,h are all integers, so division by W*H always results in 0.0, and so lerp amount is always 1.