### PR TITLE
Fixing TextBlock not passing seq_len argument when is_lm is True

### DIFF
--- a/fastai2/text/data.py
+++ b/fastai2/text/data.py
@@ -63,6 +63,7 @@ def _get_lengths(ds):
     return tok.get_lengths(ds.items)
 
 # Cell
+#TODO: add backward
 @log_args(but_as=TfmdDL.__init__)
 @delegates()
 class LMDataLoader(TfmdDL):
@@ -189,7 +190,7 @@ class TextBlock(TransformBlock):
     def __init__(self, tok_tfm, vocab=None, is_lm=False, seq_len=72, **kwargs):
         return super().__init__(type_tfms=[tok_tfm, Numericalize(vocab, **kwargs)],
                                 dl_type=LMDataLoader if is_lm else SortedDL,
-                                dls_kwargs={} if is_lm else {'before_batch': partial(pad_input_chunk, seq_len=seq_len)})
+                                dls_kwargs={'seq_len': seq_len} if is_lm else {'before_batch': partial(pad_input_chunk, seq_len=seq_len)})
 
     @classmethod
     @delegates(Tokenizer.from_df, keep=True)

--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -673,7 +673,7 @@
     "    def __init__(self, tok_tfm, vocab=None, is_lm=False, seq_len=72, **kwargs):\n",
     "        return super().__init__(type_tfms=[tok_tfm, Numericalize(vocab, **kwargs)],\n",
     "                                dl_type=LMDataLoader if is_lm else SortedDL,\n",
-    "                                dls_kwargs={} if is_lm else {'before_batch': partial(pad_input_chunk, seq_len=seq_len)})\n",
+    "                                dls_kwargs={'seq_len': seq_len} if is_lm else {'before_batch': partial(pad_input_chunk, seq_len=seq_len)})\n",
     "\n",
     "    @classmethod\n",
     "    @delegates(Tokenizer.from_df, keep=True)\n",


### PR DESCRIPTION
When I was working on my LetterTokenizer, I have noticed `seq_len` parameter of `TextBlock` is ignored if `is_lm` is set to True:

```
text_block = TextBlock(tok_tfm=tkn2, is_lm=True, seq_len=50).from_folder(path=path, is_lm=True, seq_len=50)
dls = DataBlock(
    blocks=blocks,
    get_items=get_text_files,
    get_y=None,
    splitter=splitter).dataloaders(path)
t = first(dls.train)[0][0]
print(len(t))  ## prints 72 which is the default parameter
```

I have verified that the problem is fixed is I use a modified version of `TextBlock` where `seq_len` is propagated as follows (the only difference is on line 6, setting `dls_kwargs={'seq_len': seq_len}` instead `dls_kwargs={}`)

```
class MyTextBlock(TransformBlock):
    "A `TransformBlock` for texts"
    @delegates(Numericalize.__init__)
    def __init__(self, tok_tfm, vocab=None, is_lm=False, seq_len=72, **kwargs):
        return super().__init__(type_tfms=[tok_tfm, Numericalize(vocab, **kwargs)],
                                dl_type=LMDataLoader if is_lm else SortedDL,
                                dls_kwargs={'seq_len': seq_len} if is_lm else {'before_batch': partial(pad_input_chunk, seq_len=seq_len)})

    @classmethod
    @delegates(Tokenizer.from_df, keep=True)
    def from_df(cls, text_cols, vocab=None, is_lm=False, seq_len=72, min_freq=3, max_vocab=60000, **kwargs):
        "Build a `TextBlock` from a dataframe using `text_cols`"
        return cls(Tokenizer.from_df(text_cols, **kwargs), vocab=vocab, is_lm=is_lm, seq_len=seq_len,
                   min_freq=min_freq, max_vocab=max_vocab)

    @classmethod
    @delegates(Tokenizer.from_folder, keep=True)
    def from_folder(cls, path, vocab=None, is_lm=False, seq_len=72, min_freq=3, max_vocab=60000, **kwargs):
        "Build a `TextBlock` from a `path`"
        return cls(Tokenizer.from_folder(path, **kwargs), vocab=vocab, is_lm=is_lm, seq_len=seq_len,
                   min_freq=min_freq, max_vocab=max_vocab)
```

I propose this to be fixed in fastai2. If needed, the full code can be found in Colab, https://colab.research.google.com/drive/1oaZZC7ulRLhyO8wAtBrJ3wUTbLcXjmll