### PR TITLE
Pass vocab as string when calling sklearn classification report

### DIFF
--- a/fastai2/interpret.py
+++ b/fastai2/interpret.py
@@ -98,4 +98,4 @@ class ClassificationInterpretation(Interpretation):
     def print_classification_report(self):
         "Print scikit-learn classification report"
         d,t = flatten_check(self.decoded, self.targs)
-        print(skm.classification_report(t, d, target_names=self.vocab))
+        print(skm.classification_report(t, d, target_names=[str(v) for v in self.vocab]))

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -177,7 +177,7 @@
     "    def print_classification_report(self):\n",
     "        \"Print scikit-learn classification report\"\n",
     "        d,t = flatten_check(self.decoded, self.targs)\n",
-    "        print(skm.classification_report(t, d, target_names=self.vocab))"
+    "        print(skm.classification_report(t, d, target_names=[str(v) for v in self.vocab]))"
    ]
   },
   {


### PR DESCRIPTION
**Problem:** A Dataloader's vocab can be an integer type. When calling `ClassificationInterpretation.print_classification_report()` out to `sklearn.classification_report()` sklearn expects the target label names to be strings, resulting in an exception being thrown here: (because integers have no `len` property)
```
 name_width = max(len(cn) for cn in target_names)
```

**Fix:** use vocab converted to string when calling this function: 

This kaggle notebook reproduces the problem on a simple example: https://www.kaggle.com/stillsut/fastai2-repro-1/
 - it works on MNIST when vocab is already a string
 - it fails on MNIST when vocab is an integer, this happens naturally when the source of the dataloader is a dataframe where the label is an integer type.
 - also shows that this PR fixes the problem
