### PR TITLE
ShowGraphCallback needs remove_on_fetch=True

### DIFF
--- a/fastai2/callback/progress.py
+++ b/fastai2/callback/progress.py
@@ -69,7 +69,7 @@ def no_bar(self:Learner):
 # Cell
 class ShowGraphCallback(Callback):
     "Update a graph of training and validation loss"
-    run_after,run_valid=ProgressCallback,False
+    run_after,run_valid,remove_on_fetch=ProgressCallback,False,True
 
     def begin_fit(self):
         self.run = not hasattr(self.learn, 'lr_finder') and not hasattr(self, "gather_preds")


### PR DESCRIPTION
I think this is a similar issue to #156 -- I get the same error about the Learner missing a Recorder if I'm using `ShowGraphCallback` with `SaveModelCallback` (and `WandbCallback`). 