### PR TITLE
F.interpolate compatability patch for pytorch 1.5.0

### DIFF
--- a/fastai2/vision/augment.py
+++ b/fastai2/vision/augment.py
@@ -285,7 +285,7 @@ def _grid_sample(x, coords, mode='bilinear', padding_mode='reflection', align_co
         d = min(x.shape[-2]/coords.shape[-2], x.shape[-1]/coords.shape[-1])/2
         # If we're resizing up by >200%, and we're zooming less than that, interpolate first
         if d>1 and d>z:
-            x = F.interpolate(x, scale_factor=1/d, mode='area')
+            x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
     return F.grid_sample(x, coords, mode=mode, padding_mode=padding_mode, align_corners=align_corners)
 
 # Cell

--- a/fastai2/vision/augment.py
+++ b/fastai2/vision/augment.py
@@ -285,7 +285,11 @@ def _grid_sample(x, coords, mode='bilinear', padding_mode='reflection', align_co
         d = min(x.shape[-2]/coords.shape[-2], x.shape[-1]/coords.shape[-1])/2
         # If we're resizing up by >200%, and we're zooming less than that, interpolate first
         if d>1 and d>z:
-            x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
+            # Pytorch > v1.4.x needs an extra argument when calling nn.functional.interpolate to preserve previous behaviour
+            if (int(torch.__version__[0:3].translate({ord('.'): None})) > 14):
+                x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
+                else:
+                x = F.interpolate(x, scale_factor=1/d, mode='area')
     return F.grid_sample(x, coords, mode=mode, padding_mode=padding_mode, align_corners=align_corners)
 
 # Cell

--- a/fastai2/vision/augment.py
+++ b/fastai2/vision/augment.py
@@ -286,7 +286,7 @@ def _grid_sample(x, coords, mode='bilinear', padding_mode='reflection', align_co
         # If we're resizing up by >200%, and we're zooming less than that, interpolate first
         if d>1 and d>z:
             # Pytorch > v1.4.x needs an extra argument when calling nn.functional.interpolate to preserve previous behaviour
-            if (int(torch.__version__[0:3].translate({ord('.'): None})) > 14):
+            if (int(torch.__version__[0:4].replace(".", "")) > 14):
                 x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
             else:
                 x = F.interpolate(x, scale_factor=1/d, mode='area')

--- a/fastai2/vision/augment.py
+++ b/fastai2/vision/augment.py
@@ -288,7 +288,7 @@ def _grid_sample(x, coords, mode='bilinear', padding_mode='reflection', align_co
             # Pytorch > v1.4.x needs an extra argument when calling nn.functional.interpolate to preserve previous behaviour
             if (int(torch.__version__[0:3].translate({ord('.'): None})) > 14):
                 x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
-                else:
+            else:
                 x = F.interpolate(x, scale_factor=1/d, mode='area')
     return F.grid_sample(x, coords, mode=mode, padding_mode=padding_mode, align_corners=align_corners)
 


### PR DESCRIPTION
F.interpolate, used by the RatioResize transform in fastai2’s batch image augmenter, changed it’s default behaviour between pytorch versions v1.4.0 and v1.5.0, causing installations using pytorch v1.5.0 (such as google colab) to throw a warning that using F.interpolate in this way will fail in future. Adding the argument “recompute_scale_factor=True” when calling F.interpolate prevents pytorch from throwing this warning, and ensures fastai compatibility with future versions of pytorch.