### PR TITLE
Small fix to docstring for the SentencePiece tokenizer

### DIFF
--- a/nbs/30_text.core.ipynb
+++ b/nbs/30_text.core.ipynb
@@ -1090,7 +1090,7 @@
    "source": [
     "#export\n",
     "class SentencePieceTokenizer():#TODO: pass the special tokens symbol to sp\n",
-    "    \"Spacy tokenizer for `lang`\"\n",
+    "    \"SentencePiece tokenizer for `lang`\"\n",
     "    def __init__(self, lang='en', special_toks=None, sp_model=None, vocab_sz=None, max_vocab_sz=30000,\n",
     "                 model_type='unigram', char_coverage=None, cache_dir='tmp'):\n",
     "        try: from sentencepiece import SentencePieceTrainer,SentencePieceProcessor\n",
@@ -1294,9 +1294,6 @@
   }
  ],
  "metadata": {
-  "jupytext": {
-   "split_at_heading": true
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
The SentencePiece tokenizer currently refers to Spacy' in the docstring instead of SentencePiece. This isn't a huge deal but might cause some confusion. 