### PR TITLE
sklearn classification report: pass label list

### DIFF
--- a/fastai2/interpret.py
+++ b/fastai2/interpret.py
@@ -98,4 +98,4 @@ class ClassificationInterpretation(Interpretation):
     def print_classification_report(self):
         "Print scikit-learn classification report"
         d,t = flatten_check(self.decoded, self.targs)
-        print(skm.classification_report(t, d, target_names=[str(v) for v in self.vocab]))
+        print(skm.classification_report(t, d, labels=list(self.vocab.o2i.values()), target_names=[str(v) for v in self.vocab]))

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -177,7 +177,7 @@
     "    def print_classification_report(self):\n",
     "        \"Print scikit-learn classification report\"\n",
     "        d,t = flatten_check(self.decoded, self.targs)\n",
-    "        print(skm.classification_report(t, d, target_names=[str(v) for v in self.vocab]))"
+    "        print(skm.classification_report(t, d, labels=list(self.vocab.o2i.values()), target_names=[str(v) for v in self.vocab]))"
    ]
   },
   {


### PR DESCRIPTION
I encountered this error while calling **ClassificationInterpretation.print_classification_report()**

```
/usr/local/lib/python3.6/dist-packages/sklearn/metrics/_classification.py in classification_report(y_true, y_pred, labels, target_names, sample_weight, digits, output_dict, zero_division)
   1993                 "Number of classes, {0}, does not match size of "
   1994                 "target_names, {1}. Try specifying the labels "
-> 1995                 "parameter".format(len(labels), len(target_names))
   1996             )
   1997     if target_names is None:

ValueError: Number of classes, 23, does not match size of target_names, 25. Try specifying the labels parameter
```

By my understanding, while fastai2 does pass the label names to **sklearn.metrics.classification_report()**, sklearn is given no label IDs, and thus tries to generate them from **y_true** and **y_pred**. Hence the error when some labels are not represented in either.

This PR both slightly increases efficiency (by preventing the sklearn recomputation) and fixes the problem, by plugging in the label IDs.