### PR TITLE
Update Actions Workflow To Pull The Right Contents When Running Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
 
     - name: checkout contents of PR
       uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
 
     - name: Install libraries
       run: |
@@ -81,6 +83,8 @@ jobs:
     steps:
     - name: checkout contents of PR
       uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
 
     - name: Install libraries
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 on: 
   workflow_dispatch: #allows repo admins to trigger this workflow from the Actions tab
   pull_request_target:
+  push:
+    branches: 
+      - master
 
 jobs:
   test:
@@ -12,6 +15,11 @@ jobs:
     steps:
 
     - name: checkout contents of PR
+      if: github.event_name == 'push'
+      uses: actions/checkout@v2
+
+    - name: checkout contents of PR
+      if: github.event_name == 'pull_request_target'
       uses: actions/checkout@v2
       with:
         ref: ${{github.event.pull_request.head.ref}}
@@ -83,8 +91,13 @@ jobs:
     steps:
     - name: checkout contents of PR
       uses: actions/checkout@v2
+      if: github.event_name == 'pull_request_target'
       with:
         ref: ${{github.event.pull_request.head.ref}}
+        
+    - name: checkout contents of PR
+      if: github.event_name == 'push'
+      uses: actions/checkout@v2
 
     - name: Install libraries
       run: |


### PR DESCRIPTION
We have to instruct GitHub Actions to pull the HEAD of the PR because the default is to pull [the last commit on the base branch that the PR was based on!](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target).  

Something to pay attention to @jph00 