### PR TITLE
Optionally download data in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
                 'COCO_TINY','IMDB','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE','MNIST',
                 'MNIST_SAMPLE','MNIST_TINY','PASCAL_2007','PETS']
         url_list = [URLs.__dict__[k] for k in urls]
-        parallel(untar_data, url_list, total=len(urls), progress=True)
+        parallel(untar_data, url_list, total=len(url_list), progress=True)
       shell: python
       
     - name: Test notebooks batch ${{matrix.nb}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,14 @@ jobs:
     container: fastdotai/fastai2 #this is defined here: https://github.com/fastai/docker-containers/blob/master/fastai2-build/Dockerfile
     steps:
 
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ~/.fastai
+        key: 'v1'
+
     - name: download data
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         from fastai2.data.external import untar_data, URLs
         from fastai2.torch_core import parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
                 'COCO_TINY','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE',
                 'MNIST_SAMPLE','MNIST_TINY','PASCAL_2007','PETS']
         url_list = [URLs.__dict__[k] for k in urls]
-        parallel(untar_data, url_list, total=len(url_list), progress=True)
+        parallel(untar_data, url_list, progress=True)
       shell: python
       
     - name: Test notebooks batch ${{matrix.nb}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,18 @@ jobs:
       run: |
         pip install nbdev
         pip install -e .
+        
+    - name: download data
+      run: |
+        from fastai2.data.external import untar_data
+        from fastai2.torch_core import parallel
+        from pathlib import Path
+        url_list = Path('test_data_urls.txt')
+        if url_list.exists():
+          with open(url_list, 'r') as f:
+            urls = [x.strip() for x in f.readlines()]
+          parallel(untar_data, urls, total=len(urls), progress=True)
+      shell: python
       
     - name: Test notebooks batch ${{matrix.nb}}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         from fastai2.torch_core import parallel
         from pathlib import Path
         urls = ['ADULT_SAMPLE','BIWI_SAMPLE','CAMVID_TINY','CIFAR','COCO_SAMPLE',
-                'COCO_TINY','IMDB','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE','MNIST',
+                'COCO_TINY','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE',
                 'MNIST_SAMPLE','MNIST_TINY','PASCAL_2007','PETS']
         url_list = [URLs.__dict__[k] for k in urls]
         parallel(untar_data, url_list, total=len(url_list), progress=True)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
       id: cache
       with:
         path: ~/.fastai
-        key: 'v1'
+        key: 'fastai-test-data-v1'
 
     - name: download data
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,8 +81,32 @@ jobs:
             repo: context.repo.repo,
             body: `👋 @${user}! We detected notebooks that are not stripped or that are out of sync with the library in this PR.\n\nYou need to run \`nbdev_install_git_hooks\` before submitting a pull request! For more information, see the [CONTRIBUTING](https://github.com/${{github.repository}}#contributing) guide.\n\nYou can see the logs of the tests that triggered this message in run [${{github.run_id}}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).`
           })
-        
+
+  upload:
+    runs-on: ubuntu-latest
+    container: fastdotai/fastai2 #this is defined here: https://github.com/fastai/docker-containers/blob/master/fastai2-build/Dockerfile
+    steps:
+
+    - name: download data
+      run: |
+        from fastai2.data.external import untar_data, URLs
+        from fastai2.torch_core import parallel
+        from pathlib import Path
+        urls = ['ADULT_SAMPLE','BIWI_SAMPLE','CAMVID_TINY','CIFAR','COCO_SAMPLE',
+                'COCO_TINY','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE',
+                'MNIST_SAMPLE','MNIST_TINY','PASCAL_2007','PETS']
+        url_list = [URLs.__dict__[k] for k in urls]
+        parallel(untar_data, url_list, progress=True)
+      shell: python
+
+    - name: upload data to actions artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: fastai-data
+        path: ~/.fastai
+
   test-notebooks:
+    needs: upload
     container: fastdotai/fastai2
     runs-on: ubuntu-latest
     strategy:
@@ -105,16 +129,10 @@ jobs:
         pip install -e .
         
     - name: download data
-      run: |
-        from fastai2.data.external import untar_data, URLs
-        from fastai2.torch_core import parallel
-        from pathlib import Path
-        urls = ['ADULT_SAMPLE','BIWI_SAMPLE','CAMVID_TINY','CIFAR','COCO_SAMPLE',
-                'COCO_TINY','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE',
-                'MNIST_SAMPLE','MNIST_TINY','PASCAL_2007','PETS']
-        url_list = [URLs.__dict__[k] for k in urls]
-        parallel(untar_data, url_list, progress=True)
-      shell: python
+      uses: actions/download-artifact@v2
+      with:
+        name: fastai-data
+        path: ~/.fastai
       
     - name: Test notebooks batch ${{matrix.nb}}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nb: ["[0-5]","[6-9]"]
+        nb: ['[0-2]','[3-5]','[6-9]']
     steps:
     - name: checkout contents of PR
       uses: actions/checkout@v2
@@ -118,5 +118,5 @@ jobs:
       
     - name: Test notebooks batch ${{matrix.nb}}
       run: |
-        nbdev_test_nbs --flags '' --n_workers 1 --timing True --fname "nbs/[0-9]${{matrix.nb}}*.ipynb"
+        nbdev_test_nbs --flags '' --n_workers 4 --timing True --fname "nbs/[0-9]${{matrix.nb}}*.ipynb"
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,8 @@ jobs:
     container: fastdotai/fastai2 #this is defined here: https://github.com/fastai/docker-containers/blob/master/fastai2-build/Dockerfile
     steps:
 
-    - uses: actions/cache@v2
+    - name: check for cache hit
+      uses: actions/cache@v2
       id: cache
       with:
         path: ~/.fastai
@@ -107,6 +108,7 @@ jobs:
       shell: python
 
     - name: upload data to actions artifacts
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/upload-artifact@v2
       with:
         name: fastai-data
@@ -134,8 +136,16 @@ jobs:
       run: |
         pip install nbdev
         pip install -e .
-        
-    - name: download data
+    
+    - name: attempt to download with cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ~/.fastai
+        key: 'fastai-test-data-v1'  
+ 
+    - name: download data if no cache hit
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/download-artifact@v2
       with:
         name: fastai-data

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nb: [0,1,2,3,4,5,6,7,8,9]
+        nb: ["[0-5]","[6-9]"]
     steps:
     - name: checkout contents of PR
       uses: actions/checkout@v2
@@ -106,14 +106,14 @@ jobs:
         
     - name: download data
       run: |
-        from fastai2.data.external import untar_data
+        from fastai2.data.external import untar_data, URLs
         from fastai2.torch_core import parallel
         from pathlib import Path
-        url_list = Path('test_data_urls.txt')
-        if url_list.exists():
-          with open(url_list, 'r') as f:
-            urls = [x.strip() for x in f.readlines()]
-          parallel(untar_data, urls, total=len(urls), progress=True)
+        urls = ['ADULT_SAMPLE','BIWI_SAMPLE','CAMVID_TINY','CIFAR','COCO_SAMPLE',
+                'COCO_TINY','IMDB','IMDB_SAMPLE','LSUN_BEDROOMS','ML_SAMPLE','MNIST',
+                'MNIST_SAMPLE','MNIST_TINY','PASCAL_2007','PETS']
+        url_list = [URLs.__dict__[k] for k in urls]
+        parallel(untar_data, url_list, total=len(urls), progress=True)
       shell: python
       
     - name: Test notebooks batch ${{matrix.nb}}


### PR DESCRIPTION
This is where we try to supply the data to the CI jobs.  Everything has been split into 3 batches.

@jph00 This is probably the most advanced Action I have ever written attempting to leverage [caching](https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#using-the-cache-action) as well as [artifacts](https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#:~:text=GitHub%20provides%20two%20actions%20that,data%20before%20the%20job%20ends.) as a backup incase caching doesn't work