### PR TITLE
Export to library the import of Image

### DIFF
--- a/fastai2/torch_core.py
+++ b/fastai2/torch_core.py
@@ -17,6 +17,8 @@ __all__ = ['progress_bar', 'master_bar', 'subplots', 'show_image', 'show_titled_
 from .imports import *
 from .torch_imports import *
 
+from PIL import Image
+
 # Cell
 #nbdev_comment _all_ = ['progress_bar','master_bar']
 

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -17,15 +17,8 @@
    "source": [
     "#export\n",
     "from fastai2.imports import *\n",
-    "from fastai2.torch_imports import *"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from fastai2.torch_imports import *\n",
+    "\n",
     "from PIL import Image"
    ]
   },


### PR DESCRIPTION
Library file `torch_core.py` uses `PIL.Image` in the definition of the function `to_image`. However it was not previously imported.

Now, `torch_core.py` includes the import:
```
from PIL import Image
```